### PR TITLE
Remove osmiumbullet.icon table entry

### DIFF
--- a/Clowns-Processing/prototypes/items/vanilla-items.lua
+++ b/Clowns-Processing/prototypes/items/vanilla-items.lua
@@ -372,9 +372,21 @@ data:extend(
       flow_color = {r = 0.71, g = 0.816, b = 0},
       max_temperature = 100,
     },
-    --Osmium Bullets
+    
   }
 )
+
+local function getIndex(tab, val)
+    local index = nil
+    for i, v in ipairs (tab) do 
+        if (v.id == val) then
+          index = i 
+        end
+    end
+    return index
+end
+
+--Osmium Bullets
 osmiumbullet=table.deepcopy(data.raw.ammo["uranium-rounds-magazine"])
 osmiumbullet.name="osmium-rounds-magazine"
 if osmiumbullet.ammo_type.action and osmiumbullet.ammo_type.action.action_delivery then
@@ -384,7 +396,10 @@ else
   table.insert(osmiumbullet.ammo_type.action,{action_delivery={target_effects={{damage = {amount = 20, type = "physical"}},{type = "damage", damage = { amount = 6, type = "explosion"}}}}})
 end
 osmiumbullet.order = "a[basic-clips]-d[osmium-rounds-magazine]"
-osmiumbullet.icon = nil
+
+local idx = getIndex(osmiumbullet, icon) -- id = icon found at idx = __
+table.remove(osmiumbullet, idx) -- remove Table[__] and shift remaining entries
+
 osmiumbullet.icons = {
   {icon = "__Clowns-Processing__/graphics/icons/osmium-rounds-magazine.png", icon_size = 64, icon_mipmaps = 4--[[, tint = {95,56,75}]]}
 }


### PR DESCRIPTION
Setting osmiumbullet.icon to nil still leaves the entry in the table. This can interfere with other mods that modify or parse ammo. My specific example is with Endgame Combat which makes ammo crates. Having the icon entry exist was causing a crash from the nil value. I've submitted an issue on their end to better handle icon & icons entries, but this could affect other mods.

I've been able to fix the issue by entirely removing the icon entry, not just setting to nil.