### PR TITLE
Point centrifuging-2 prerequisite at bob-tungsten-processing (alloy-processing removed in Bob 2.1)

### DIFF
--- a/Clowns-Processing/prototypes/technology-updates.lua
+++ b/Clowns-Processing/prototypes/technology-updates.lua
@@ -49,7 +49,6 @@ end
 
 OV.add_prereq("angels-advanced-chemistry-3", "mercury-processing-1")
 OV.add_prereq("uranium-ammo", "advanced-depleted-uranium-smelting-1")
-if mods["bobplates"] then
-OV.add_prereq("centrifuging-2", "bob-tungsten-alloy-processing")
---OV.add_prereq("centrifuging-2", "bob-tungsten-processing")
+if data.raw.technology["bob-tungsten-processing"] then
+OV.add_prereq("centrifuging-2", "bob-tungsten-processing")
 end


### PR DESCRIPTION
`bob-tungsten-alloy-processing` was removed in Bob 2.1, but `technology-updates.lua` still added it as a prerequisite of `centrifuging-2` (guarded only by `mods["bobplates"]`), referencing a non-existent technology under current Bob.

This points the prerequisite at the still-existing `bob-tungsten-processing` technology (already present, previously commented out) and guards on its existence. `centrifuging-2` keeps its tungsten-processing dependency instead of silently losing it.