### PR TITLE
Restore if/else around molten-iron-smelting-6 / molten-steel-smelting-c2

### DIFF
--- a/Clowns-Processing/prototypes/recipes/angels-smelting.lua
+++ b/Clowns-Processing/prototypes/recipes/angels-smelting.lua
@@ -3,6 +3,7 @@ local recipe={}
 angelsmods.trigger.smelting_products["iron"].plate = true
 angelsmods.trigger.smelting_products["iron"].ingot = true
   angelsmods.trigger.smelting_products["manganese"].ingot = true
+if mods["bobplates"] or (mods["angelsindustries"] and angelsmods.industries.overhaul) then
   --iron ingot recipes
   recipe[#recipe+1]=
   {
@@ -29,7 +30,7 @@ angelsmods.trigger.smelting_products["iron"].ingot = true
     order = "i[liquid-molten-iron]-f",
     crafting_machine_tint = angelsmods.functions.get_fluid_recipe_tint("angels-liquid-molten-iron"),
   }
- --include a magnesium sink for vanilla cases
+else --include a magnesium sink for vanilla cases
   recipe[#recipe+1]=
   {
     type = "recipe",
@@ -55,6 +56,7 @@ angelsmods.trigger.smelting_products["iron"].ingot = true
     order = "i[liquid-molten-iron]-b",
     crafting_machine_tint = angelsmods.functions.get_fluid_recipe_tint("angels-liquid-molten-steel"),
   }
+end
 --aluminium ingot recipes
 if angelsmods.trigger.smelting_products["aluminium"].plate then
   recipe[#recipe+1]=


### PR DESCRIPTION
Fixes #77

The 1.1 source wrapped `molten-iron-smelting-6` and `molten-steel-smelting-c2` in a single `if/else` so exactly one was added: the iron recipe under bobplates / overhauled angelsindustries, and the steel recipe as the vanilla-only magnesium-sink fallback. The 2.0 port lost the `if`, `else` and `end`, so both recipes were added unconditionally — giving a bobplates configuration two `angels-liquid-molten-steel` producers and a Factoriopedia number-badge collision with `angels-liquid-molten-steel-2`.

This restores the original conditional. The trigger flags above the block are left unconditional, as before.
